### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 This MCP (Multi-platform Communication Protocol) server provides access to Korea Meteorological Administration (KMA) APIs, allowing AI agents to retrieve weather forecast information for locations in South Korea.
 
+<a href="https://glama.ai/mcp/servers/@jikime/py-mcp-ko-weather">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@jikime/py-mcp-ko-weather/badge" alt="Python Korea Weather Service MCP server" />
+</a>
+
 ## Overview
 
 - Retrieve precise grid coordinates for Korean administrative regions


### PR DESCRIPTION
This PR adds a badge for the [Python MCP Korea Weather Service](https://glama.ai/mcp/servers/@jikime/py-mcp-ko-weather) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@jikime/py-mcp-ko-weather">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@jikime/py-mcp-ko-weather/badge" alt="Python Korea Weather Service MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.